### PR TITLE
Fix `DrawRect` syntax on both the v3 and v4 Function pages

### DIFF
--- a/docs/RSDKv3/Functions/Drawing/DrawRect.md
+++ b/docs/RSDKv3/Functions/Drawing/DrawRect.md
@@ -41,7 +41,7 @@ None.
 
 ## Syntax
 ```
-DrawTintRect(int iXPos, int iYPos, int Width, int Height, int R, int G, int B, int Alpha)
+DrawRect(int iXPos, int iYPos, int Width, int Height, int R, int G, int B, int Alpha)
 ```
 
 ## Example

--- a/docs/RSDKv4/Functions/Drawing/DrawRect.md
+++ b/docs/RSDKv4/Functions/Drawing/DrawRect.md
@@ -41,7 +41,7 @@ None.
 
 ## Syntax
 ```
-DrawTintRect(int ixpos, int iypos, int width, int height, int r, int g, int b, int alpha)
+DrawRect(int ixpos, int iypos, int width, int height, int r, int g, int b, int alpha)
 ```
 
 ## Example


### PR DESCRIPTION
it was using `DrawTintRect` instead of `DrawRect`