### PR TITLE
fix RSDKv3 Rotate Palette incorrect syntax

### DIFF
--- a/docs/RSDKv3/Functions/Drawing/RotatePalette.md
+++ b/docs/RSDKv3/Functions/Drawing/RotatePalette.md
@@ -4,7 +4,6 @@
 Rotates all colors in the active palette bank from `StartIndex` to `EndIndex`, moving left or right depending on `RotRight`.
 
 ## Parameters
-
 `StartIndex`
 
 :   The starting index of the palette bank for the rotation.

--- a/docs/RSDKv3/Functions/Drawing/RotatePalette.md
+++ b/docs/RSDKv3/Functions/Drawing/RotatePalette.md
@@ -1,12 +1,9 @@
 # RotatePalette <small>(RSDKv3)</small>
 
 ## Description
-Rotates all colors in `PalBank` from `StartIndex` to `EndIndex`, moving left or right depending on `RotRight`.
+Rotates all colors in the active palette bank from `StartIndex` to `EndIndex`, moving left or right depending on `RotRight`.
 
 ## Parameters
-`PalBank`
-
-:   The ID of the palette bank for the palette to rotate. Indices 0-7 are valid.
 
 `StartIndex`
 
@@ -25,10 +22,10 @@ None.
 
 ## Syntax
 ```
-RotatePalette(int PalBank, int StartIndex, int EndIndex, bool RotRight)
+RotatePalette(int StartIndex, int EndIndex, bool RotRight)
 ```
 
 ## Example
 ```
-RotatePalette(2, 16, 24, 1)
+RotatePalette(16, 24, 1)
 ```


### PR DESCRIPTION
`RotatePalette` in RSDKv3's function page used the v4 Syntax