### PR TITLE
Migrate wiki to Zensical

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -4,26 +4,36 @@ on:
     paths:
       - docs/**
       - overrides/**
-      - .github/github-pages-deploy.yml
+      - .github/workflows/github-pages-deploy.yml
       - mkdocs.yml
     branches:
       - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 env:
   CI: True
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    env:
-      MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/configure-pages@v5
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
-      - run: pip install mkdocs-material mkdocs-glightbox mkdocs-git-committers-plugin-2 mkdocs-git-revision-date-localized-plugin
-      - run: mkdocs gh-deploy --force
+      - run: pip install zensical
+      - run: zensical build --clean
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -21,5 +21,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material mkdocs-glightbox
-      - run: mkdocs build -v
+      - run: pip install zensical
+      - run: zensical build --clean

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     RSDK Modding Wiki
 </h1>
 
-Website with documentation, resources, and guides for Retro Engine modding, powered by [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) and inspired by [HedgeDocs](https://hedgedocs.com/).
+Website with documentation, resources, and guides for Retro Engine modding, powered by [Zensical](https://zensical.org/) and inspired by [HedgeDocs](https://hedgedocs.com/).
 
 > [!WARNING]
 > This site is a heavy work-in-progress. Expect missing information and empty/placeholder pages. Everything is subject to change.
@@ -24,18 +24,18 @@ Adding a new page to the wiki is easy! After creating a fork of this repository,
 
 After you added your contributions, open a pull request, and if approved, your page will be shown in the wiki for the whole world to see.
 
-### Material for MkDocs features
+### Zensical features
 
-Since this wiki uses Material for MkDocs, you might want to check its [references](https://squidfunk.github.io/mkdocs-material/reference/) to better understand its features. You can use plain Markdown, but you can also use admonitions, buttons, and even icons from Font Awesome.
+Since this wiki uses Zensical, you might want to check its [documentation](https://zensical.org/docs/authoring/markdown/) to better understand its features. You can use plain Markdown, but you can also use admonitions, buttons, and even icons from Font Awesome.
 
 ### Testing
 
 You can test your changes locally before committing. To do so:
 
 - Install [Python](https://www.python.org/downloads/)
-- Install Material For MkDocs and the necessary plug-ins: `pip install mkdocs-material mkdocs-glightbox --upgrade`
-- Serve webpage locally: `mkdocs serve --livereload`
-    - You can also build a static site instead, using `mkdocs build`
+- Install Zensical: `pip install zensical --upgrade`
+- Serve webpage locally: `zensical serve --open`
+    - You can also build a static site instead, using `zensical build --clean`
 
 The served webpage will auto refresh whenever you make changes to the files.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ edit_uri: edit/master/docs/
 copyright: Not affiliated with Evening Star or SEGA
 theme:
   name: material
+  variant: classic
   custom_dir: overrides
   logo: assets/icon.png
   favicon: assets/icon.png


### PR DESCRIPTION
This PR migrates the wiki from [(Material for)](https://squidfunk.github.io/mkdocs-material/) [MkDocs](https://www.mkdocs.org/) to [Zensical](https://zensical.org/). The current 1.x version of MkDocs has been unmaintained since mid-2024, and this is already starting to introduce major bugs that will likely never get fixed. In addition, the upcoming MkDocs 2.0 will introduce several breaking changes that will make our wiki incompatible with it; see [this blog post](https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/) for more information. Due to this, I believe it's in the best interest of this wiki to move from MkDocs as soon as possible.

Zensical is designed to be backwards compatible with Material for MkDocs sites with little to no modification to them required. It doesn't have 1:1 feature parity yet, but it has everything we need to get this wiki working (besides support for the git plugins and glightbox, but that isn't critical functionality and [support is being actively worked on](https://zensical.org/compatibility/plugins/)). Besides being actively maintained, Zensical also has faster build times and better performance.

Currently, however, Zensical doesn't have an equivalent to MkDocs' `gh-deploy` command, so we have to handle deploying manually. I've rewrote the deployment workflow CI based on the documentation's [publishing guide](https://zensical.org/docs/publish-your-site/#github-pages), but I'm not sure if it works with the rsdkmodding.com domain since I don't own it; @Mefiresu will have to test the CI.