### PR TITLE
Correct `layer` description for Get/SetTileLayerEntry

### DIFF
--- a/docs/RSDKv3/RetroScript/Functions/Stages/GetTileLayerEntry.md
+++ b/docs/RSDKv3/RetroScript/Functions/Stages/GetTileLayerEntry.md
@@ -9,12 +9,7 @@ Gets the ID of the chunk at `ChunkX`, `ChunkY` in tile layer `Layer` and stores 
 
 `Layer`
 
-:   The ID of the layer where the chunk comes from. The valid values are:
-
-:   - 0 (`DEFORM_FG`)
-:   - 1 (`DEFORM_FG_WATER`)
-:   - 2 (`DEFORM_BG`)
-:   - 3 (`DEFORM_BG_WATER`)
+:   The ID of the layer where the chunk comes from. 0 represents the foreground layer, while 1-8 represent background layers 1-8.
 
 `ChunkX`
 

--- a/docs/RSDKv3/RetroScript/Functions/Stages/SetTileLayerEntry.md
+++ b/docs/RSDKv3/RetroScript/Functions/Stages/SetTileLayerEntry.md
@@ -9,12 +9,7 @@ Sets the chunk at `ChunkX`, `ChunkY` in tile layer `Layer` to the index of `Valu
 
 `Layer`
 
-:   The ID of the layer where the chunk comes from. The valid values are:
-
-:   - 0 (`DEFORM_FG`)
-:   - 1 (`DEFORM_FG_WATER`)
-:   - 2 (`DEFORM_BG`)
-:   - 3 (`DEFORM_BG_WATER`)
+:   The ID of the layer to set the chunk in. 0 represents the foreground layer, while 1-8 represent background layers 1-8.
 
 `ChunkX`
 

--- a/docs/RSDKv4/RetroScript/Functions/Stages/GetTileLayerEntry.md
+++ b/docs/RSDKv4/RetroScript/Functions/Stages/GetTileLayerEntry.md
@@ -9,12 +9,7 @@ Gets the ID of the chunk at `chunkX`, `chunkY` in tile layer `layer` and stores 
 
 `layer`
 
-:   The ID of the layer where the chunk comes from. The valid values are:
-
-:   - 0 (`DEFORM_FG`)
-:   - 1 (`DEFORM_FG_WATER`)
-:   - 2 (`DEFORM_BG`)
-:   - 3 (`DEFORM_BG_WATER`)
+:   The ID of the layer where the chunk comes from. 0 represents the foreground layer, while 1-8 represent background layers 1-8.
 
 `chunkX`
 

--- a/docs/RSDKv4/RetroScript/Functions/Stages/SetTileLayerEntry.md
+++ b/docs/RSDKv4/RetroScript/Functions/Stages/SetTileLayerEntry.md
@@ -9,12 +9,7 @@ Sets the chunk at `chunkX`, `chunkY` in tile layer `layer` to the index of `valu
 
 `layer`
 
-:   The ID of the layer where the chunk comes from. The valid values are:
-
-:   - 0 (`DEFORM_FG`)
-:   - 1 (`DEFORM_FG_WATER`)
-:   - 2 (`DEFORM_BG`)
-:   - 3 (`DEFORM_BG_WATER`)
+:   The ID of the layer to set the chunk in. 0 represents the foreground layer, while 1-8 represent background layers 1-8.
 
 `chunkX`
 


### PR DESCRIPTION
Previously, the `layer` parameter descriptions for the RSDKv3/v4 `Get`/`SetTileLayerEntry` functions was described in the same manner as `SetLayerDeformation`'s `layer` parameter. However, despite the matching names, the way the parameter is used actually differs between the functions. This PR corrects that, for all applicable pages.