### PR TITLE
Correct "unused" entries on Origins Audio page

### DIFF
--- a/docs/Games/SonicOrigins/Documentation/Audio.md
+++ b/docs/Games/SonicOrigins/Documentation/Audio.md
@@ -46,14 +46,16 @@ CRIWARE audio packs are encrypted, and require a keycode unique to each pack in 
 | 11 | 85_z3_SpringYard   | SpringYard.ogg        |
 | 12 | 86_z6_ScrapBrain   | ScrapBrain.ogg        |
 | 13 | 87_Invincibility   | Invincibility.ogg     |
-| 14 | 89_SpecialStage    | Specialstage.ogg      |
+| 14 | 89_SpecialStage    | Specialstage.ogg[^2]  |
+| 14 | 89_SpecialStage    | SpecialStage.ogg[^2]  |
 | 15 | 8C_Boss            | Boss.ogg              |
 | 16 | 8D_Final           | Final.ogg             |
 | 17 | 92_Drowning        | Drowning.ogg          |
-| 18 | 93_ChaosEmerald    | Stage/Emerald.wav[^2] |
+| 18 | 93_ChaosEmerald    | Stage/Emerald.wav[^3] |
 
 [^1]: The jingles for 1UPs in Sonic 1 & 2 use an RSDK filename of simply `1up`. To get around issues involving the jingles being music in CRIWARE but sound effects in RSDK, the SFX RFL parameters include a `m_music` field that allows playing a song by audio name while playing a sound effect, which the `_SE_1Up` entries do by setting their music fields to `1up`. For the sake of clarity, these tables list the actual sound effect filenames instead.
-[^2]: The jingles for obtaining a Chaos Emerald in Sonic 1 & 2 use an RSDK filename of simply `emerald`, similar to the `1up` entries.[^1] The `_SE_Emerald` sound effect parameter entries set their `m_music` fields to `emerald`. For the sake of clarity, these tables list the actual sound effect filenames instead.
+[^2]: `Specialstage.ogg` is used in the Special Stages, while `SpecialStage.ogg` is used in the Level Select's sound test.
+[^3]: The jingles for obtaining a Chaos Emerald in Sonic 1 & 2 use an RSDK filename of simply `emerald`, similar to the `1up` entries.[^1] The `_SE_Emerald` sound effect parameter entries set their `m_music` fields to `emerald`. For the sake of clarity, these tables list the actual sound effect filenames instead.
 
 ### Fast Music
 All fast (Speed Shoes) music plays the original music at 1.2x speed.
@@ -75,7 +77,6 @@ These entries exist in the RFL parameters but are duplicates of others or have n
 | ------------------ | ---------------- |
 | _BGM_MainMenu.ogg  | MainMenu.ogg     |
 | _BGM_MenuIntro.ogg | MenuIntro.ogg    |
-| 89_SpecialStage    | SpecialStage.ogg |
 
 ## Sonic CD Music (SCD_music.awb) { id="sonic-cd-music" }
 | ID | CRIWARE Audio Name                       | RSDK Filename        |
@@ -155,39 +156,42 @@ These entries exist in the RFL parameters but are duplicates of others or have n
 | 72 | RSDK_SCD_J---TimeAttack                  | JP/TimeAttack.ogg    |
 
 ## Sonic 2 Music (STH2_music.awb) { id="sonic-2-music" }
-| ID | CRIWARE Audio Name | RSDK Filename     |
-| -- | ------------------ | ----------------- |
-| 0  | 02_EmeraldHill     | EmeraldHill.ogg   |
-| 1  | 03_MysticCave2     | MysticCave2.ogg   |
-| 2  | 04_OilOcean        | OilOcean.ogg      |
-| 3  | 05_Metropolis      | Metropolis.ogg    |
-| 4  | 06_HillTop         | HillTop.ogg       |
-| 5  | 07_AquaticRuin     | AquaticRuin.ogg   |
-| 6  | 08_CasinoNight2    | CasinoNight2.ogg  |
-| 7  | 09_CasinoNight     | CasinoNight.ogg   |
-| 8  | 0A_DeathEgg        | DeathEgg.ogg      |
-| 9  | 0B_MysticCave      | MysticCave.ogg    |
-| 10 | 0C_EmeraldHill2    | EmeraldHill2.ogg  |
-| 11 | 0D_SkyChase        | SkyChase.ogg      |
-| 12 | 0E_ChemicalPlant   | ChemicalPlant.ogg |
-| 13 | 0F_WingFortress    | WingFortress.ogg  |
-| 14 | 11_Options         | Options.ogg       |
-| 15 | 12_SpecialStage    | SpecialStage.ogg  |
-| 16 | 13_Boss            | Boss.ogg          |
-| 17 | 14_FinalBoss       | FinalBoss.ogg     |
-| 18 | 16_Super           | Super.ogg         |
-| 19 | 17_Invincibility   | Invincibility.ogg |
-| 20 | 01_Results         | Results.ogg       |
-| 21 | 10_Extra           | Extra.ogg         |
-| 22 | 15_Ending          | Ending.ogg        |
-| 23 | 19_TitleScreen     | Titlescreen.ogg   |
-| 24 | 1A_ActComplete     | ActComplete.ogg   |
-| 25 | 1B_GameOver        | GameOver.ogg      |
-| 26 | 1C_Continue        | Continue.ogg      |
-| 27 | 1E_Credits         | Credits.ogg       |
+| ID | CRIWARE Audio Name | RSDK Filename        |
+| -- | ------------------ | -------------------- |
+| 0  | 02_EmeraldHill     | EmeraldHill.ogg      |
+| 1  | 03_MysticCave2     | MysticCave2.ogg      |
+| 2  | 04_OilOcean        | OilOcean.ogg         |
+| 3  | 05_Metropolis      | Metropolis.ogg       |
+| 4  | 06_HillTop         | HillTop.ogg          |
+| 5  | 07_AquaticRuin     | AquaticRuin.ogg      |
+| 6  | 08_CasinoNight2    | CasinoNight2.ogg     |
+| 7  | 09_CasinoNight     | CasinoNight.ogg      |
+| 8  | 0A_DeathEgg        | DeathEgg.ogg         |
+| 9  | 0B_MysticCave      | MysticCave.ogg       |
+| 10 | 0C_EmeraldHill2    | EmeraldHill2.ogg     |
+| 11 | 0D_SkyChase        | SkyChase.ogg         |
+| 12 | 0E_ChemicalPlant   | ChemicalPlant.ogg    |
+| 13 | 0F_WingFortress    | WingFortress.ogg     |
+| 14 | 11_Options         | Options.ogg          |
+| 15 | 12_SpecialStage    | SpecialStage.ogg     |
+| 16 | 13_Boss            | Boss.ogg             |
+| 17 | 14_FinalBoss       | FinalBoss.ogg        |
+| 18 | 16_Super           | Super.ogg            |
+| 19 | 17_Invincibility   | Invincibility.ogg    |
+| 20 | 01_Results         | Results.ogg          |
+| 21 | 10_Extra           | Extra.ogg            |
+| 22 | 15_Ending          | Ending.ogg           |
+| 23 | 19_TitleScreen     | Titlescreen.ogg[^4]  |
+| 23 | 19_TitleScreen     | TitleScreen.ogg[^4]  |
+| 24 | 1A_ActComplete     | ActComplete.ogg      |
+| 25 | 1B_GameOver        | GameOver.ogg         |
+| 26 | 1C_Continue        | Continue.ogg         |
+| 27 | 1E_Credits         | Credits.ogg          |
 
 !!! note
     Sonic 2 shares its 1-UP, Drowning, and Chaos Emerald jingles with Sonic 1, as the songs stored in `STH1_music.awb` are played in both games.
+
+[^4]: `Titlescreen.ogg` is used on the Title Screen, while `TitleScreen.ogg` is used in the Level Select's sound test.
 
 ### Fast Music
 All fast (Speed Shoes) music plays the original music at 1.2x speed.
@@ -216,7 +220,6 @@ These entries exist in the RFL parameters but are duplicates of others or have n
 | ------------------ | --------------- |
 | _BGM_MainMenu      | MainMenu.ogg    |
 | _BGM_MenuIntro     | MenuIntro.ogg   |
-| 19_TitleScreen     | TitleScreen.ogg |
 
 ## Sonic 3 & Knuckles Music (Music03_S3K.awb) { id="sonic-3-knuckles-music" }
 | ID | CRIWARE Audio Name               | RSDK Filename                         |


### PR DESCRIPTION
On the page for Sonic Origins's Audio RFL parameters, some used entries are incorrectly marked as unused. This PR fixes that, as well as adding small footnotes clarifying the purpose of having duplicates.

In Sonic Origins, the RSDK file names in the Reflection files are case-sensitive. However, the games themselves are not always consistent with the capitalisation, as seen with S2's Title Screen music and S1's Special Stage music paths differing between their in-context locations and their Level Select sound test appearances. As such, Sonic Team opted to fix this by simply duplicating the entries for those music tracks in the RFL files.