### PR TITLE
Remove erroneous entry on Origins Audio Page

### DIFF
--- a/docs/Games/SonicOrigins/Documentation/Audio.md
+++ b/docs/Games/SonicOrigins/Documentation/Audio.md
@@ -204,7 +204,6 @@ All fast (Speed Shoes) music plays the original music at 1.2x speed.
 | 07_AquaticRuin     | AquaticRuin_F.ogg   |
 | 08_CasinoNight2    | CasinoNight2_F.ogg  |
 | 09_CasinoNight     | CasinoNight_F.ogg   |
-| 0A_DeathEgg        | DeathEgg_F.ogg      |
 | 0B_MysticCave      | MysticCave_F.ogg    |
 | 0C_EmeraldHill2    | EmeraldHill2_F.ogg  |
 | 0E_ChemicalPlant   | ChemicalPlant_F.ogg |


### PR DESCRIPTION
On the page, a `DeathEgg_F.ogg` cue is listed in the Speed Shoes section. However, within the Retro RFL Parameter file for Origins, no such listing is actually found.