### PR TITLE
Fix incorrect Native Object name

### DIFF
--- a/docs/RSDKv4/RetroScript/Functions/Misc/CallNativeFunction/NativePlayerWaitingAds.md
+++ b/docs/RSDKv4/RetroScript/Functions/Misc/CallNativeFunction/NativePlayerWaitingAds.md
@@ -3,16 +3,16 @@
 !!! note
     This native function only exists in the Sega Forever versions of Sonic 1 (3.9.0 and later) and Sonic 2 (1.7.0 and later).
 
-Creates a `RewardAds` native object, prompting the player to watch an ad.
+Creates a `ReviveAds` native object, prompting the player to watch an ad.
 
 ## Parameters
 None.
 
 ## Return Value
-If `Yes` is selected and an ad plays, `waitingAds.result` is set to `1`. If `No` is selected, it's set to `2`.
+If `Yes` is selected, and an ad plays, `waitingAds.result` is set to `1`. If `No` is selected, it's set to `2`.
 
 !!! note
-    The `RewardAds` native object does not exist in the RSDKv4 decompilation; instead, `waitingAds.result` is always set to `2`.
+    The `ReviveAds` native object does not exist in the RSDKv4 decompilation; instead, `waitingAds.result` is always set to `2`.
 
 ## Example
 ```

--- a/docs/RSDKv4/RetroScript/Functions/Misc/CallNativeFunction/NativeWaterPlayerWaitingAds.md
+++ b/docs/RSDKv4/RetroScript/Functions/Misc/CallNativeFunction/NativeWaterPlayerWaitingAds.md
@@ -3,16 +3,16 @@
 !!! note
     This native function only exists in the Sega Forever versions of Sonic 1 (3.9.0 and later) and Sonic 2 (1.7.0 and later).
 
-Creates a `RewardAds` native object, prompting the player to watch an ad.
+Creates a `ReviveAds` native object, prompting the player to watch an ad.
 
 ## Parameters
 None.
 
 ## Return Value
-If `Yes` is selected and an ad plays, `waitingAds.water` is set to `1`. If `No` is selected, it's set to `2`.
+If `Yes` is selected, and an ad plays, `waitingAds.water` is set to `1`. If `No` is selected, it's set to `2`.
 
 !!! note
-    The `RewardAds` native object does not exist in the RSDKv4 decompilation; instead, `waitingAds.water` is always set to `2`.
+    The `ReviveAds` native object does not exist in the RSDKv4 decompilation; instead, `waitingAds.water` is always set to `2`.
 
 ## Example
 ```

--- a/docs/RSDKv4/RetroScript/Functions/Misc/CallNativeFunction/PlayVideo.md
+++ b/docs/RSDKv4/RetroScript/Functions/Misc/CallNativeFunction/PlayVideo.md
@@ -3,12 +3,14 @@
 !!! note
     This native function only exists in SEGA Classics (2018) and is not available in the decompilations.
 
-Loads and plays a video stored inside the `res/raw/` folder of the APK. Similar to the v3 counterpart, the videos are stored in an `.mp4` file format
+Loads and plays a video.
+
+The videos are located outside of the datapack, inside the `res/raw/` folder of the APK. Like the mobile releases of RSDKv3, they use the `.mp4` file format.
 
 ## Parameters
 `filePath`
 
-:   The path to the video file, relative to the root of `res/raw/` folder.
+:   The path to the video file, relative to the root of the `res/raw/` folder.
 
 `unused`
 

--- a/docs/RSDKv4/RetroScript/Functions/Misc/CallNativeFunction/README.md
+++ b/docs/RSDKv4/RetroScript/Functions/Misc/CallNativeFunction/README.md
@@ -63,8 +63,8 @@ CallNativeFunction4(NotifyCallback, NOTIFY_STATS_ENEMY, StageStatsUsabilityParam
 ### Version Exclusive
 | Function                                                          | Version                              | Description                                                                                             |
 | ----------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| [**NativePlayerWaitingAds**](NativePlayerWaitingAds.md)           | [Sega Forever](TODO)                 | Creates a `RewardAds` native object, prompting the player to watch an ad after dying.                   |
-| [**NativeWaterPlayerWaitingAds**](NativeWaterPlayerWaitingAds.md) | [Sega Forever](TODO)                 | Creates a `RewardAds` native object, prompting the player to watch an ad after drowning.                |
+| [**NativePlayerWaitingAds**](NativePlayerWaitingAds.md)           | [Sega Forever](TODO)                 | Creates a `ReviveAds` native object, prompting the player to watch an ad after dying.                   |
+| [**NativeWaterPlayerWaitingAds**](NativeWaterPlayerWaitingAds.md) | [Sega Forever](TODO)                 | Creates a `ReviveAds` native object, prompting the player to watch an ad after drowning.                |
 | [**NotifyCallback**](NotifyCallback.md)                           | [Sonic Origins](/Games/SonicOrigins) | Sends the given callback to communicate to [Hedgehog Engine 2](/Games/SonicOrigins/HedgehogEngine2). |
 | [**PlayVideo**](PlayVideo.md)                                     | [Sega Classics](TODO)                | Loads and plays a video. **Not available in the decompilations.**                                       |
 


### PR DESCRIPTION
The currently used "RewardAds" name is inaccurate, as it has always been named "ReviveAds", even in the S1/S2 versions that are documented in their pages.

PlayVideo's page was also tweaked for the sake of clarity.